### PR TITLE
Multiple Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ $ npm install -g node-red-dev
 $ node-red-dev COMMAND
 running command...
 $ node-red-dev (-v|--version|version)
-node-red-dev/0.1.1 darwin-arm64 node-v16.13.0
+node-red-dev/0.1.2 darwin-arm64 node-v16.13.0
 $ node-red-dev --help [COMMAND]
 USAGE
   $ node-red-dev COMMAND
@@ -47,7 +47,6 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v3.2.3/src/commands/help.ts)_
 
 ## `node-red-dev validate`
 
@@ -69,5 +68,4 @@ DESCRIPTION
   you can also specify a path with --path or a published npm package with --npm.
 ```
 
-_See code: [src/commands/validate.js](https://github.com/node-red/node-red-dev-cli/blob/v0.1.1/src/commands/validate.js)_
 <!-- commandsstop -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-dev",
-  "version": "0.0.11",
+  "version": "0.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-dev",
-      "version": "0.0.11",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/command": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-red-dev",
   "description": "Node-RED Node Developer Tools",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "Sam Machin @sammachin",
   "bin": {
     "node-red-dev": "./bin/run"
@@ -56,7 +56,6 @@
     "postpack": "rm -f oclif.manifest.json",
     "posttest": "eslint .",
     "prepack": "oclif-dev manifest && oclif-dev readme",
-    "test": "nyc mocha --forbid-only \"test/**/*.test.js\"",
-    "version": "oclif-dev readme && git add README.md"
+    "test": "nyc mocha --forbid-only \"test/**/*.test.js\""
   }
 }

--- a/src/libs/checknodes.js
+++ b/src/libs/checknodes.js
@@ -178,7 +178,7 @@ function checknodes(path, cli, scorecard, npm_metadata) {
         new Promise((resolve, reject) => {
             files = []
             if (fs.existsSync(path+'/examples')){
-                files = getAllFiles(path+'/examples')
+                files = getAllFiles(path+'/examples').filter(x => {if (pth.extname(x) == '.json') {return x}} )
             }
             resolve(files)
         })

--- a/src/libs/checknodes.js
+++ b/src/libs/checknodes.js
@@ -163,7 +163,8 @@ function checknodes(path, cli, scorecard, npm_metadata) {
                         cli.warn(`Duplicate nodename ${nodename} found in package ${m.id}`)
                     }
                 })
-            })  
+            })
+            scorecard.N01.nodes = scorecard.N01.nodes.filter((x, i) => i === scorecard.N01.nodes.indexOf(x))  
         })
         .then(() => {
             if (scorecard.N01.test){

--- a/src/libs/checkpackage.js
+++ b/src/libs/checkpackage.js
@@ -110,7 +110,7 @@ function checkpackage(path, cli, scorecard, npm_metadata) {
             }    
         }
         if (!scopedRegex.test(package.name)) {
-            const contribRegex = new RegExp('/^(node-red|nodered)(?!-contrib-).*/ig')
+            const contribRegex = new RegExp('^(node-red|nodered)(?!-contrib-).*', 'i')
             if (contribRegex.test(package.name)){
                 cli.warn('P04 Packages using the node-red prefix in their name must use node-red-contrib')
                 scorecard.P04 = { 'test' : false}
@@ -118,8 +118,9 @@ function checkpackage(path, cli, scorecard, npm_metadata) {
                 cli.log('✅ Package uses a valid name')
                 scorecard.P04 = { 'test' : true}
             }
-
-
+        } else {
+            cli.log('✅ Package uses a Scoped Name')
+            scorecard.P04 = { 'test' : true}
         }         
     })
     .then(() => {

--- a/src/libs/checkpackage.js
+++ b/src/libs/checkpackage.js
@@ -32,7 +32,7 @@ function checkpackage(path, cli, scorecard, npm_metadata) {
             cli.log(`✅ Package is ${package.license} licensed`)
             scorecard.P01 = {'test' : true, 'license' : package.license}
         } else {
-            cli.error('No License Specified')
+            cli.warn('No License Specified')
             scorecard.P01 = {'test' : false}
         }
       })


### PR DESCRIPTION
Fix for non json files in examples causing  `node-red-contrib-xkeys_backlight` to fail

Fix for missing license causing exit on `node-red-contrib-azure-iothub-2-adt` 

Dedupe of conflicting node to fix https://github.com/node-red/node-red-dev-cli/issues/4

Fix for naming check regex incorrectly reporting `node-red-knex` as passing

Bump version to 0.1.2