### PR TITLE
catch failed node parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-red-dev",
   "description": "Node-RED Node Developer Tools",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": "Sam Machin @sammachin",
   "bin": {
     "node-red-dev": "./bin/run"

--- a/src/libs/checknodes.js
+++ b/src/libs/checknodes.js
@@ -195,13 +195,18 @@ function checknodes(path, cli, scorecard, npm_metadata) {
                 })
                 allnodes = [...checknodes]
                 files.forEach((file) => {
-                    let example = JSON.parse(fs.readFileSync(file));
+                    try {
+                        let example = JSON.parse(fs.readFileSync(file));
                     example.forEach((n) => {
                         const index = checknodes.indexOf(n.type);
                         if (index > -1) {
                             checknodes.splice(index, 1);
                         }
                     })
+                    } catch (error){
+                        cli.warn("Unable to read example : "+file)
+                    }
+                    
                 })
                 let examplenodes = allnodes.filter(x => !checknodes.includes(x))
                 if (checknodes.length != 0){

--- a/src/libs/checknodes.js
+++ b/src/libs/checknodes.js
@@ -98,7 +98,7 @@ function getNodeDefinitions(filename) {
                 }
             });
         } catch(err) {
-            console.log(p);
+            //console.log(p);
 
             errors.push({
                 code:"parse",
@@ -141,8 +141,13 @@ function checknodes(path, cli, scorecard, npm_metadata) {
     return new Promise((resolve, reject) => {
         cli.log('    ---Validating Nodes---')
         Object.values(package['node-red'].nodes).forEach((n) =>{
-            let htmlfile = path+"/"+n.replace(".js", ".html")
+            try {
+                let htmlfile = path+"/"+n.replace(".js", ".html")
             Object.assign(defs, getNodeDefinitions(htmlfile))
+            } catch (error){
+                console.log('Unable to parse ',n)
+            }
+            
         })    
         resolve();
       })

--- a/src/libs/checknodes.js
+++ b/src/libs/checknodes.js
@@ -4,6 +4,7 @@ const fs = require("fs");
 const axios = require('axios')
 const pth = require("path");
 const { pathToFileURL } = require('url');
+const util = require('util');
 
 
 function getNodeDefinitions(filename) {

--- a/src/libs/checkpackage.js
+++ b/src/libs/checkpackage.js
@@ -211,7 +211,7 @@ function checkpackage(path, cli, scorecard, npm_metadata) {
                     scorecard.P07.version = package.engines.node
                 } else {
                     cli.warn('P07 Minimum Node version is not compatible with minimum supported Node-RED Version Node v'+nminversion)
-                    scorecard.P07 = { 'test' : fail}
+                    scorecard.P07 = { 'test' : false}
                     scorecard.P07.version = package.engines.node
                 }
             })


### PR DESCRIPTION
Wrap the node parser in a try to gracefully fail if nodes are programatically generated