### PR TITLE
Only check prod dependency versions

### DIFF
--- a/src/libs/checkdeps.js
+++ b/src/libs/checkdeps.js
@@ -7,12 +7,12 @@ const readline = require('readline').createInterface({
     output: process.stdout
   });
 const npmls = require('npm-remote-ls').ls;
-//let npmls_config = require('npm-remote-ls').config 
-//npmls_config({
-//  development: false,
-//  optional: false
-//})
- 
+const npmls_config = require('npm-remote-ls').config
+npmls_config({
+    development: false,
+    optional: false
+})
+
 const { resolve } = require('path');
 const util = require('util');
 const npmCheck = require('npm-check');


### PR DESCRIPTION
Hello,
This PR (edit: partially) reverts https://github.com/node-red/node-red-dev-cli/commit/629790abf4628aa35bda7ed96d13069e13105c93 which did the opposite of what it claimed, and produced a regression in https://github.com/node-red/node-red-dev-cli/pull/3

Currently, Scorecard is wrongly flagging bad packages, even when they are a dev dependency...
Example: https://flows.nodered.org/node/node-red-contrib-postgresql/scorecard
![image](https://user-images.githubusercontent.com/1008324/152259453-3c8fd3c1-e0f8-43a7-9a66-f9b0095c0614.png)

This (my) node has no dependency to `agent-base`, which is though a sub-sub dev dependency of https://www.npmjs.com/package/mustache