### PR TITLE
Fix P04 node naming check

### DIFF
--- a/src/libs/checkpackage.js
+++ b/src/libs/checkpackage.js
@@ -100,16 +100,14 @@ function checkpackage(path, cli, scorecard, npm_metadata) {
                 legacy = true
             }
         }
-        if (!legacy){
-            if (scopedRegex.test(package.name)){
-                cli.log('✅ Package uses a Scoped Name')
-                scorecard.P04 = { 'test' : true}
-            } else {
-                cli.warn('P04 New Packages should use a scoped name')
-                scorecard.P04 = { 'test' : false}
-            }    
-        }
-        if (!scopedRegex.test(package.name)) {
+
+        if (scopedRegex.test(package.name)){
+            cli.log('✅ Package uses a Scoped Name')
+            scorecard.P04 = { 'test' : true}
+        } else if (!legacy){
+            cli.warn('P04 New Packages should use a scoped name')
+            scorecard.P04 = { 'test' : false}
+        } else {
             const contribRegex = new RegExp('^(node-red|nodered)(?!-contrib-).*', 'i')
             if (!contribRegex.test(package.name)){
                 cli.log('✅ Package uses a valid name')
@@ -121,10 +119,7 @@ function checkpackage(path, cli, scorecard, npm_metadata) {
                 cli.warn('P04 Packages using the node-red prefix in their name must use node-red-contrib')
                 scorecard.P04 = { 'test' : false}
             }
-        } else {
-            cli.log('✅ Package uses a Scoped Name')
-            scorecard.P04 = { 'test' : true}
-        }         
+        }      
     })
     .then(() => {
         //Check for other package of same name in different scope, ask about fork? P08


### PR DESCRIPTION
In case of a

- non-legacy node (that is a node registered for the first time after 31.01.2022)
- having a unscoped name yet conforming to legacy specification

the current implementation

- issues a [warning](https://github.com/node-red/node-red-dev-cli/blob/2595fbb2bfc4b96f3de0963ea660831c8f79122f/src/libs/checkpackage.js#L108) in combination with setting flag `'test' : false`
- yet then confirms a [valid name](https://github.com/node-red/node-red-dev-cli/blob/2595fbb2bfc4b96f3de0963ea660831c8f79122f/src/libs/checkpackage.js#L113-L116) & sets the `'test' : true` flag

 This PR alters the sequence of the checks to ensure that non-legacy nodes get flagged as `'test' : false` when having an unscoped name.
