### PR TITLE
Do not cache packages between invocations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "node-red-dev",
-  "version": "0.1.1",
+  "version": "0.1.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "node-red-dev",
-      "version": "0.1.1",
+      "version": "0.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@oclif/command": "^1.8.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "node-red-dev",
   "description": "Node-RED Node Developer Tools",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "author": "Sam Machin @sammachin",
   "bin": {
     "node-red-dev": "./bin/run"

--- a/src/commands/validate.js
+++ b/src/commands/validate.js
@@ -53,6 +53,10 @@ class ValidateCommand extends Command {
     await checkpackage(path, cli, scorecard, npm_metadata)
     .then(scorecard => {
       let pkg = require(path+'/package.json')
+      // Remove the file from the module-cache so if we're being run
+      // programmatically we don't cache previous versions
+      delete require.cache[require.resolve(path+'/package.json')]
+
       if (!pkg['node-red'].hasOwnProperty('nodes')){ //If no nodes declared skip node validation (could be a plugin)
         cli.warn('No nodes declared in package.json')
         return(scorecard)

--- a/src/libs/checkdeps.js
+++ b/src/libs/checkdeps.js
@@ -21,6 +21,10 @@ const semver = require('semver');
 
 function checkdeps(path, cli, scorecard, npm_metadata) {
     const package = require(path+'/package.json');
+    // Remove the file from the module-cache so if we're being run
+    // programmatically we don't cache previous versions
+    delete require.cache[require.resolve(path+'/package.json')]
+
     return new Promise((resolve, reject) => {
         cli.log('    ---Validating Dependencies---')    
         resolve();

--- a/src/libs/checknodes.js
+++ b/src/libs/checknodes.js
@@ -138,6 +138,10 @@ const getAllFiles = function(dirPath, arrayOfFiles) {
 
 function checknodes(path, cli, scorecard, npm_metadata) {
     const package = require(path+'/package.json')
+    // Remove the file from the module-cache so if we're being run
+    // programmatically we don't cache previous versions
+    delete require.cache[require.resolve(path+'/package.json')]
+
     let defs = {}
     return new Promise((resolve, reject) => {
         cli.log('    ---Validating Nodes---')

--- a/src/libs/checkpackage.js
+++ b/src/libs/checkpackage.js
@@ -20,6 +20,10 @@ function isGitUrl(str) {
 
 function checkpackage(path, cli, scorecard, npm_metadata) {
     const package = require(path+'/package.json');
+    // Remove the file from the module-cache so if we're being run
+    // programmatically we don't cache previous versions
+    delete require.cache[require.resolve(path+'/package.json')]
+
     return new Promise((resolve, reject) => {
         cli.log('    ---Validating Package---')
         cli.log(`   ${package.name}@${package.version}`)  
@@ -71,6 +75,7 @@ function checkpackage(path, cli, scorecard, npm_metadata) {
     //                let path = r.workdir()
     //            }
     //            let repopackage = require(path+'/package.json')
+    //            delete require.cache[require.resolve(path+'/package.json')]
     //            if (package.name != repopackage.name){
     //                cli.warn('P02 Package name does not match package.json in repository')
     //                scorecard.P02 = {'test' : false}


### PR DESCRIPTION
When called programmatically from the flow library, the path to a particular module's package.json is always the same regardless of the version. This meant node.js was caching the results of the `require` calls for the package.json - leading to the scorecard evaluating the old version.

This ensures nothing is cached.